### PR TITLE
Re-enable attestation check and bump artefact versions to 5.0.0

### DIFF
--- a/docker/Dockerfile.azure-cleanroom-samples
+++ b/docker/Dockerfile.azure-cleanroom-samples
@@ -1,6 +1,6 @@
 # Override hooks for controlling az cleanroom extension version and installation source.
 ARG EXTENSION_SOURCE=official
-ARG EXTENSION_FILENAME=cleanroom-4.0.0-py2.py3-none-any
+ARG EXTENSION_FILENAME=cleanroom-5.0.0-py2.py3-none-any
 
 FROM mcr.microsoft.com/powershell AS docker-azcli-base
 # Required packages.
@@ -52,8 +52,8 @@ FROM samples-base AS install-extension-official
 ARG EXTENSION_FILENAME
 ONBUILD RUN echo "Installing clean room extension '${EXTENSION_FILENAME}' from official source."
 ONBUILD WORKDIR /home/scratch
-ONBUILD RUN oras pull mcr.microsoft.com/azurecleanroom/cli/cleanroom-whl:4.0.0
-ONBUILD RUN az extension add --source /home/scratch/cleanroom-4.0.0-py2.py3-none-any.whl -y --allow-preview true
+ONBUILD RUN oras pull mcr.microsoft.com/azurecleanroom/cli/cleanroom-whl:5.0.0
+ONBUILD RUN az extension add --source /home/scratch/cleanroom-5.0.0-py2.py3-none-any.whl -y --allow-preview true
 
 FROM samples-base AS install-extension-local
 # Install WHL from local source.

--- a/docker/ccf/docker-compose.yaml
+++ b/docker/ccf/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # to find the CCF provider container as part of a compose project and look for a 'client-1'
   # container within.
   client:
-    image: mcr.microsoft.com/azurecleanroom/ccf/ccf-provider-client:4.0.0
+    image: mcr.microsoft.com/azurecleanroom/ccf/ccf-provider-client:5.0.0
     ports:
       - "0:8080"
     environment:

--- a/scripts/contract/confirm-deployment-artefacts.ps1
+++ b/scripts/contract/confirm-deployment-artefacts.ps1
@@ -52,15 +52,13 @@ $containerImages += $resources.properties.initContainers |`
 
 $containerTag = $resources.tags."accr-version"
 if ($null -eq $containerTag) {
-    $containerTag = "4.0.0"
+    $containerTag = "5.0.0"
 }
 
-<# TODO Re-enable once the attestation issue on the published containers is fixed.
 Assert-CleanroomAttestation `
     -containerImages $containerImages `
     -tempDir $privateDir `
     -containerTag $containerTag
-#>
 
 Write-Log Verbose `
     "Accepting deployment template proposal '$proposalId'..."


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Re-introduces attestation-based checks for container images
* Bumps up versions to 5.0.0

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Version bump
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->