### PR TITLE
Fix cases of attestation verification failing on re-runs

### DIFF
--- a/scripts/common/assert-cleanroomattestation.ps1
+++ b/scripts/common/assert-cleanroomattestation.ps1
@@ -34,7 +34,7 @@ function Assert-CleanroomAttestation {
         if (Test-Path "$tempDir/$digest.jsonl") {
             Write-Log Information "Attestation file '$tempDir/$digest.jsonl' already exists. Reusing..."
         }
-        else{
+        else {
             # Fetch attestation from GitHub API.
             $attestationResult = curl -L "https://api.github.com/repos/$repo/attestations/$digest" | ConvertFrom-Json
             if ($attestationResult.Length -ne 1) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Attestation checks were failing on re-runs, possibly due to a delete and re-create of jsonl files in very quick succession. Since the files are hash-based, a re-fetch is guaranteed to have the same set of values. So, if the file already exists, it can be re-used instead of a delete and re-create. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->