### PR TITLE
Update READMEs: fix quota wording, add EUAP requirement, add --no-wait

### DIFF
--- a/demos/analytics-using-managedcleanroom/README-API.md
+++ b/demos/analytics-using-managedcleanroom/README-API.md
@@ -99,7 +99,6 @@ providing your own data and query.
 | PowerShell | 7.x+ |
 | MSAL.PS module | `Install-Module MSAL.PS -Scope CurrentUser -Force` |
 | azcopy | v10+ (CPK mode only) |
-| EUAP access | Go to [aka.ms/lionrock](https://aka.ms/lionrock) → **On Demand Quota** → Enter service and subscription details → Select region as **EastUS2EUAP** → Select **ARM access without quota** in the next page |
 
 > **Quota check:** This sample deploys an AKS cluster and Confidential ACI
 > container groups in the **West US** region. Ensure your subscription has the

--- a/demos/analytics-using-managedcleanroom/README-API.md
+++ b/demos/analytics-using-managedcleanroom/README-API.md
@@ -99,6 +99,7 @@ providing your own data and query.
 | PowerShell | 7.x+ |
 | MSAL.PS module | `Install-Module MSAL.PS -Scope CurrentUser -Force` |
 | azcopy | v10+ (CPK mode only) |
+| EUAP access | Go to [aka.ms/lionrock](https://aka.ms/lionrock) → **On Demand Quota** → Enter service and subscription details → Select region as **EastUS2EUAP** → Select **ARM access without quota** in the next page |
 
 > **Quota check:** This sample deploys an AKS cluster and Confidential ACI
 > container groups in the **West US** region. Ensure your subscription has the
@@ -112,7 +113,9 @@ providing your own data and query.
 > The above covers a single query execution (1 Spark driver + up to 3
 > executors, each using 1 vCPU). Spark pods are provisioned at runtime and
 > removed after query execution completes. Multiple queries can run
-> concurrently — add 4 vCPUs of Ddsv5 quota per additional concurrent query.
+> concurrently — add 4 vCPUs of Confidential ACI quota per additional concurrent query.
+>
+> You can get the required quota for the region by going to [aka.ms/lionrock](https://aka.ms/lionrock) → **On Demand Quota** and entering the relevant details.
 
 > The `managedcleanroom` CLI extension is **not required** for this guide.
 

--- a/demos/analytics-using-managedcleanroom/README-API.md
+++ b/demos/analytics-using-managedcleanroom/README-API.md
@@ -113,8 +113,6 @@ providing your own data and query.
 > executors, each using 1 vCPU). Spark pods are provisioned at runtime and
 > removed after query execution completes. Multiple queries can run
 > concurrently — add 4 vCPUs of Confidential ACI quota per additional concurrent query.
->
-> You can get the required quota for the region by going to [aka.ms/lionrock](https://aka.ms/lionrock) → **On Demand Quota** and entering the relevant details.
 
 > The `managedcleanroom` CLI extension is **not required** for this guide.
 

--- a/demos/analytics-using-managedcleanroom/README-CLI.md
+++ b/demos/analytics-using-managedcleanroom/README-CLI.md
@@ -234,7 +234,7 @@ az managedcleanroom collaboration create `
     --resource-group $collabRg `
     --location $rpLocation `
     --resource-location $resourceLocation `
-    --collaborators "[{UserIdentifier:'$collaboratorEmail'}]"
+    --collaborators "[{UserIdentifier:'$collaboratorEmail'}]" `
     --no-wait
 ```
 
@@ -260,7 +260,7 @@ do {
 az managedcleanroom collaboration enable-workload `
     --collaboration-name $collabName `
     --resource-group $collabRg `
-    --workload-type analytics `
+    --workload-type Analytics `
     --no-wait
 ```
 

--- a/demos/analytics-using-managedcleanroom/README-CLI.md
+++ b/demos/analytics-using-managedcleanroom/README-CLI.md
@@ -98,7 +98,6 @@ providing your own data and query.
 | PowerShell | 7.x+ |
 | MSAL.PS module | `Install-Module MSAL.PS -Scope CurrentUser -Force` |
 | azcopy | v10+ (CPK mode only) |
-| EUAP access | Go to [aka.ms/lionrock](https://aka.ms/lionrock) → **On Demand Quota** → Enter service and subscription details → Select region as **EastUS2EUAP** → Select **ARM access without quota** in the next page |
 
 > **Quota check:** This sample deploys an AKS cluster and Confidential ACI
 > container groups in the **West US** region. Ensure your subscription has the
@@ -114,7 +113,7 @@ providing your own data and query.
 > removed after query execution completes. Multiple queries can run
 > concurrently — add 4 vCPUs of Confidential ACI quota per additional concurrent query.
 >
-> You can get the required quota for the region by going to [aka.ms/lionrock](https://aka.ms/lionrock) → **On Demand Quota** and entering the relevant details.
+> For test purposes, if you have insufficient quota, you can get the required quota for the region by going to [aka.ms/lionrock](https://aka.ms/lionrock) → **On Demand Quota** and entering the relevant details.
 
 ### 1.2 Terminal T1 (Owner) — Variables
 

--- a/demos/analytics-using-managedcleanroom/README-CLI.md
+++ b/demos/analytics-using-managedcleanroom/README-CLI.md
@@ -112,8 +112,6 @@ providing your own data and query.
 > executors, each using 1 vCPU). Spark pods are provisioned at runtime and
 > removed after query execution completes. Multiple queries can run
 > concurrently — add 4 vCPUs of Confidential ACI quota per additional concurrent query.
->
-> For test purposes, if you have insufficient quota, you can get the required quota for the region by going to [aka.ms/lionrock](https://aka.ms/lionrock) → **On Demand Quota** and entering the relevant details.
 
 ### 1.2 Terminal T1 (Owner) — Variables
 

--- a/demos/analytics-using-managedcleanroom/README-CLI.md
+++ b/demos/analytics-using-managedcleanroom/README-CLI.md
@@ -98,6 +98,7 @@ providing your own data and query.
 | PowerShell | 7.x+ |
 | MSAL.PS module | `Install-Module MSAL.PS -Scope CurrentUser -Force` |
 | azcopy | v10+ (CPK mode only) |
+| EUAP access | Go to [aka.ms/lionrock](https://aka.ms/lionrock) → **On Demand Quota** → Enter service and subscription details → Select region as **EastUS2EUAP** → Select **ARM access without quota** in the next page |
 
 > **Quota check:** This sample deploys an AKS cluster and Confidential ACI
 > container groups in the **West US** region. Ensure your subscription has the
@@ -111,7 +112,9 @@ providing your own data and query.
 > The above covers a single query execution (1 Spark driver + up to 3
 > executors, each using 1 vCPU). Spark pods are provisioned at runtime and
 > removed after query execution completes. Multiple queries can run
-> concurrently — add 4 vCPUs of Ddsv5 quota per additional concurrent query.
+> concurrently — add 4 vCPUs of Confidential ACI quota per additional concurrent query.
+>
+> You can get the required quota for the region by going to [aka.ms/lionrock](https://aka.ms/lionrock) → **On Demand Quota** and entering the relevant details.
 
 ### 1.2 Terminal T1 (Owner) — Variables
 
@@ -233,7 +236,8 @@ az managedcleanroom collaboration create `
     --collaboration-name $collabName `
     --resource-group $collabRg `
     --location $location `
-    --collaborators "[{UserIdentifier:'$collaboratorEmail'}]"
+    --collaborators "[{UserIdentifier:'$collaboratorEmail'}]" `
+    --no-wait
 ```
 
 > The `--collaborators` flag adds collaborators at creation time itself.
@@ -258,7 +262,8 @@ do {
 az managedcleanroom collaboration enable-workload `
     --collaboration-name $collabName `
     --resource-group $collabRg `
-    --workload-type analytics
+    --workload-type analytics `
+    --no-wait
 ```
 
 **Runtime**: ~7 minutes. Poll `collaborationState` until `Provisioned`:


### PR DESCRIPTION
Changes to both README-CLI.md and README-API.md:

1. Changed '4 vCPUs of Ddsv5 quota' to '4 vCPUs of Confidential ACI quota'
2. Added EUAP access requirement to the 1.1 Requirements table
3. Added note on how to get required quota for the region via aka.ms/lionrock
4. Added `--no-wait` to `collaboration create` command (CLI only)
5. Added `--no-wait` to `enable-workload` command (CLI only)