### PR TITLE
Add Grafana dashboards section to README-API

### DIFF
--- a/demos/analytics-using-managedcleanroom/README-API.md
+++ b/demos/analytics-using-managedcleanroom/README-API.md
@@ -744,33 +744,15 @@ $bytes = [Convert]::FromBase64String($kc.kubeconfig)
     Out-File "./readonly.kubeconfig" -Encoding utf8
 ```
 
-### 12.2 Get Admin Credentials
+### 12.2 Open Grafana Dashboard
+
+Retrieves admin credentials, opens the browser, and port-forwards to Grafana.
 
 ```powershell
-$encoded = kubectl --kubeconfig ./readonly.kubeconfig `
-    get secret cleanroom-spark-grafana -n telemetry `
-    -o jsonpath="{.data.admin-password}"
-$password = [System.Text.Encoding]::UTF8.GetString(
-    [Convert]::FromBase64String($encoded))
-Write-Host "Admin password: $password"
+./demos/analytics-using-managedcleanroom/scripts/12-open-grafana-dashboard.ps1 -KubeConfigPath "./readonly.kubeconfig"
 ```
 
-Username is `admin`.
-
-### 12.3 Port-Forward to Grafana
-
-Keep this terminal open while accessing Grafana.
-
-```powershell
-kubectl --kubeconfig ./readonly.kubeconfig `
-    port-forward svc/cleanroom-spark-grafana 3000:80 -n telemetry
-```
-
-### 12.4 Access Dashboards
-
-1. Open `http://localhost:3000`
-2. Login with `admin` / password from Step 12.2
-3. Navigate to **Dashboards** for Spark monitoring
+Login with `admin` and the password printed by the script.
 
 ---
 

--- a/demos/analytics-using-managedcleanroom/README-API.md
+++ b/demos/analytics-using-managedcleanroom/README-API.md
@@ -52,6 +52,7 @@ providing your own data and query.
 | 09 — Execute query | &#10003; | | Woodgrove triggers execution |
 | 10 — Monitor query | &#10003; | &#10003; | Any collaborator can poll |
 | 11 — Results & audit | &#10003; | &#10003; | Woodgrove downloads; both view audit |
+| 12 — Grafana dashboards | &#10003; | | Owner monitors via admin credentials |
 
 ---
 
@@ -78,6 +79,7 @@ providing your own data and query.
 - [Step 09: Execute Query](#step-09-execute-query) `[WOODGROVE]`
 - [Step 10: Monitor Query](#step-10-monitor-query) `[ANY]`
 - [Step 11: Results & Audit](#step-11-results--audit) `[WOODGROVE]`
+- [Step 12: Grafana Dashboards](#step-12-grafana-dashboards) `[OWNER]`
 - [Appendix A: Federated Credential Subject Reference](#appendix-a-federated-credential-subject-reference)
 - [Appendix B: Troubleshooting](#appendix-b-troubleshooting)
 - [Appendix C: CPK Deep Dive](#appendix-c-cpk-deep-dive)
@@ -98,6 +100,7 @@ providing your own data and query.
 | PowerShell | 7.x+ |
 | MSAL.PS module | `Install-Module MSAL.PS -Scope CurrentUser -Force` |
 | azcopy | v10+ (CPK mode only) |
+| kubectl | Latest stable |
 | Resource provider | `Microsoft.CleanRoom` registered in the owner's subscription |
 | Feature flags | `EUAPParticipation` (see below) |
 
@@ -722,6 +725,53 @@ Auto-detects SSE/CPK mode from metadata. Pass `-JobId` to filter to a specific r
 
 ---
 
+## Step 12: Grafana Dashboards `[OWNER]`
+
+> Grafana dashboards let the owner monitor Spark query execution,
+> resource usage, and logs in real time.
+
+### 12.1 Get Readonly Kubeconfig
+
+```powershell
+$kc = az rest --method POST `
+    --url "$collabArmUrl/getReadonlyKubeConfig`?api-version=$armApiVersion" `
+    --resource $armResource -o json | ConvertFrom-Json
+
+$bytes = [Convert]::FromBase64String($kc.kubeconfig)
+[System.Text.Encoding]::UTF8.GetString($bytes) |
+    Out-File "./readonly.kubeconfig" -Encoding utf8
+```
+
+### 12.2 Port-Forward to Grafana
+
+Keep this terminal open while accessing Grafana.
+
+```powershell
+kubectl --kubeconfig ./readonly.kubeconfig `
+    port-forward svc/cleanroom-grafana 3000:80 -n observability
+```
+
+### 12.3 Get Admin Credentials
+
+```powershell
+$encoded = kubectl --kubeconfig ./readonly.kubeconfig `
+    get secret cleanroom-grafana -n observability `
+    -o jsonpath="{.data.admin-password}"
+$password = [System.Text.Encoding]::UTF8.GetString(
+    [Convert]::FromBase64String($encoded))
+Write-Host "Admin password: $password"
+```
+
+Username is `admin`.
+
+### 12.4 Access Dashboards
+
+1. Open `http://localhost:3000`
+2. Login with `admin` / password from Step 12.3
+3. Navigate to **Dashboards** for Spark monitoring
+
+---
+
 ## Appendix A: Federated Credential Subject Reference
 
 Format: `{contractId}-{ownerId}` where `contractId` = `"Analytics"` (capital A)
@@ -820,6 +870,7 @@ API version: `2026-03-31-preview`
 | Show collaboration | GET | `.../providers/Microsoft.CleanRoom/Collaborations/{name}` |
 | Enable workload | POST | `.../Collaborations/{name}/enableWorkload` |
 | Add collaborator | POST | `.../Collaborations/{name}/addCollaborator` |
+| Get readonly kubeconfig | POST | `.../Collaborations/{name}/getReadonlyKubeConfig` |
 
 ### Frontend API (via `Invoke-RestMethod`)
 

--- a/demos/analytics-using-managedcleanroom/README-API.md
+++ b/demos/analytics-using-managedcleanroom/README-API.md
@@ -742,20 +742,11 @@ $bytes = [Convert]::FromBase64String($kc.kubeconfig)
     Out-File "./readonly.kubeconfig" -Encoding utf8
 ```
 
-### 12.2 Port-Forward to Grafana
-
-Keep this terminal open while accessing Grafana.
-
-```powershell
-kubectl --kubeconfig ./readonly.kubeconfig `
-    port-forward svc/cleanroom-grafana 3000:80 -n observability
-```
-
-### 12.3 Get Admin Credentials
+### 12.2 Get Admin Credentials
 
 ```powershell
 $encoded = kubectl --kubeconfig ./readonly.kubeconfig `
-    get secret cleanroom-grafana -n observability `
+    get secret cleanroom-spark-grafana -n telemetry `
     -o jsonpath="{.data.admin-password}"
 $password = [System.Text.Encoding]::UTF8.GetString(
     [Convert]::FromBase64String($encoded))
@@ -764,10 +755,19 @@ Write-Host "Admin password: $password"
 
 Username is `admin`.
 
+### 12.3 Port-Forward to Grafana
+
+Keep this terminal open while accessing Grafana.
+
+```powershell
+kubectl --kubeconfig ./readonly.kubeconfig `
+    port-forward svc/cleanroom-spark-grafana 3000:80 -n telemetry
+```
+
 ### 12.4 Access Dashboards
 
 1. Open `http://localhost:3000`
-2. Login with `admin` / password from Step 12.3
+2. Login with `admin` / password from Step 12.2
 3. Navigate to **Dashboards** for Spark monitoring
 
 ---

--- a/demos/analytics-using-managedcleanroom/README-CLI.md
+++ b/demos/analytics-using-managedcleanroom/README-CLI.md
@@ -744,33 +744,15 @@ $bytes = [Convert]::FromBase64String($kc.kubeconfig)
     Out-File "./readonly.kubeconfig" -Encoding utf8
 ```
 
-### 12.2 Get Admin Credentials
+### 12.2 Open Grafana Dashboard
+
+Retrieves admin credentials, opens the browser, and port-forwards to Grafana.
 
 ```powershell
-$encoded = kubectl --kubeconfig ./readonly.kubeconfig `
-    get secret cleanroom-spark-grafana -n telemetry `
-    -o jsonpath="{.data.admin-password}"
-$password = [System.Text.Encoding]::UTF8.GetString(
-    [Convert]::FromBase64String($encoded))
-Write-Host "Admin password: $password"
+./demos/analytics-using-managedcleanroom/scripts/12-open-grafana-dashboard.ps1 -KubeConfigPath "./readonly.kubeconfig"
 ```
 
-Username is `admin`.
-
-### 12.3 Port-Forward to Grafana
-
-Keep this terminal open while accessing Grafana.
-
-```powershell
-kubectl --kubeconfig ./readonly.kubeconfig `
-    port-forward svc/cleanroom-spark-grafana 3000:80 -n telemetry
-```
-
-### 12.4 Access Dashboards
-
-1. Open `http://localhost:3000`
-2. Login with `admin` / password from Step 12.2
-3. Navigate to **Dashboards** for Spark monitoring
+Login with `admin` and the password printed by the script.
 
 ---
 

--- a/demos/analytics-using-managedcleanroom/README-CLI.md
+++ b/demos/analytics-using-managedcleanroom/README-CLI.md
@@ -52,6 +52,7 @@ providing your own data and query.
 | 09 — Execute query | &#10003; | | Woodgrove triggers execution |
 | 10 — Monitor query | &#10003; | &#10003; | Any collaborator can poll |
 | 11 — Results & audit | &#10003; | &#10003; | Woodgrove downloads; both view audit |
+| 12 — Grafana dashboards | &#10003; | | Owner monitors via admin credentials |
 
 ---
 
@@ -77,6 +78,7 @@ providing your own data and query.
 - [Step 09: Execute Query](#step-09-execute-query) `[WOODGROVE]`
 - [Step 10: Monitor Query](#step-10-monitor-query) `[ANY]`
 - [Step 11: Results & Audit](#step-11-results--audit) `[WOODGROVE]`
+- [Step 12: Grafana Dashboards](#step-12-grafana-dashboards) `[OWNER]`
 - [Appendix A: Federated Credential Subject Reference](#appendix-a-federated-credential-subject-reference)
 - [Appendix B: Troubleshooting](#appendix-b-troubleshooting)
 - [Appendix C: CPK Deep Dive](#appendix-c-cpk-deep-dive)
@@ -98,6 +100,7 @@ providing your own data and query.
 | PowerShell | 7.x+ |
 | MSAL.PS module | `Install-Module MSAL.PS -Scope CurrentUser -Force` |
 | azcopy | v10+ (CPK mode only) |
+| kubectl | Latest stable |
 
 > **Quota check:** This sample deploys an AKS cluster and Confidential ACI
 > container groups in the `$resourceLocation` region (**West US** by default). Ensure your subscription has the
@@ -721,6 +724,53 @@ Auto-detects SSE/CPK mode from metadata. Pass `-JobId` to filter to a specific r
 ```
 
 > Output CSVs are saved to `generated/output/`. Without `-JobId`, downloads the latest.
+
+---
+
+## Step 12: Grafana Dashboards `[OWNER]`
+
+> Grafana dashboards let the owner monitor Spark query execution,
+> resource usage, and logs in real time.
+
+### 12.1 Get Readonly Kubeconfig
+
+```powershell
+$kc = az managedcleanroom collaboration get-readonly-kube-config `
+    --collaboration-name $collabName `
+    --resource-group $collabRg -o json | ConvertFrom-Json
+
+$bytes = [Convert]::FromBase64String($kc.kubeconfig)
+[System.Text.Encoding]::UTF8.GetString($bytes) |
+    Out-File "./readonly.kubeconfig" -Encoding utf8
+```
+
+### 12.2 Get Admin Credentials
+
+```powershell
+$encoded = kubectl --kubeconfig ./readonly.kubeconfig `
+    get secret cleanroom-spark-grafana -n telemetry `
+    -o jsonpath="{.data.admin-password}"
+$password = [System.Text.Encoding]::UTF8.GetString(
+    [Convert]::FromBase64String($encoded))
+Write-Host "Admin password: $password"
+```
+
+Username is `admin`.
+
+### 12.3 Port-Forward to Grafana
+
+Keep this terminal open while accessing Grafana.
+
+```powershell
+kubectl --kubeconfig ./readonly.kubeconfig `
+    port-forward svc/cleanroom-spark-grafana 3000:80 -n telemetry
+```
+
+### 12.4 Access Dashboards
+
+1. Open `http://localhost:3000`
+2. Login with `admin` / password from Step 12.2
+3. Navigate to **Dashboards** for Spark monitoring
 
 ---
 

--- a/demos/analytics-using-managedcleanroom/scripts/12-open-grafana-dashboard.ps1
+++ b/demos/analytics-using-managedcleanroom/scripts/12-open-grafana-dashboard.ps1
@@ -1,0 +1,31 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$KubeConfigPath,
+    [int]$LocalPort = 3000
+)
+
+$GrafanaSecretName = "cleanroom-spark-grafana"
+$GrafanaNamespace = "telemetry"
+$GrafanaService = "cleanroom-spark-grafana"
+
+# Get admin credentials
+Write-Host "Reading Grafana admin credentials..."
+$encoded = kubectl --kubeconfig $KubeConfigPath `
+    get secret $GrafanaSecretName -n $GrafanaNamespace `
+    -o jsonpath="{.data.admin-password}"
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to read Grafana admin secret '$GrafanaSecretName' in namespace '$GrafanaNamespace'."
+}
+$password = [System.Text.Encoding]::UTF8.GetString(
+    [Convert]::FromBase64String($encoded))
+Write-Host "Username: admin"
+Write-Host "Password: $password"
+
+# Print URL for user to open
+$url = "http://localhost:$LocalPort"
+Write-Host "`nGrafana will be available at: $url"
+
+# Port-forward (blocks until Ctrl+C)
+Write-Host "`nPort-forwarding $GrafanaService to localhost:$LocalPort (Ctrl+C to stop)..."
+kubectl --kubeconfig $KubeConfigPath `
+    port-forward svc/$GrafanaService ${LocalPort}:80 -n $GrafanaNamespace


### PR DESCRIPTION
Changes

- [README-API.md]— Added Step 12: Grafana Dashboards covering:
12.1 Obtaining a readonly kubeconfig via getReadonlyKubeConfig ARM API
12.2 Retrieving Grafana admin credentials from K8s secret
12.3 Port-forwarding to the Grafana service
12.4 Accessing pre-configured Spark monitoring dashboards

- Added kubectl to prerequisites, Step 12 to the summary table/TOC, and getReadonlyKubeConfig to the API reference (Appendix F)