### PR TITLE
README-API: scope Woodgrove input to a date subdirectory by default

### DIFF
--- a/demos/analytics-using-managedcleanroom/README-API.md
+++ b/demos/analytics-using-managedcleanroom/README-API.md
@@ -75,6 +75,10 @@ providing your own data and query.
 - [Step 04: Provision Resources & Upload Data](#step-04-provision-resources--upload-data) `[EACH COLLABORATOR]`
 - [Step 05: OIDC Identity & Access](#step-05-oidc-identity--access) `[EACH COLLABORATOR]`
 - [Step 06: Publish Datasets](#step-06-publish-datasets) `[EACH COLLABORATOR]`
+  - [6.1 Build Dataset Body JSON](#61-build-dataset-body-json)
+  - [6.2 Publish Input Dataset](#62-publish-input-dataset)
+  - [6.3 Publish Output Dataset (Woodgrove only)](#63-publish-output-dataset-woodgrove-only)
+  - [6.4 Prepare CPK Keys (CPK mode only)](#64-prepare-cpk-keys-cpk-mode-only)
 - [Step 07: Publish Query](#step-07-publish-query) `[WOODGROVE]`
 - [Step 08: Approve Query](#step-08-approve-query) `[EACH COLLABORATOR]`
 - [Step 09: Execute Query](#step-09-execute-query) `[WOODGROVE]`
@@ -485,8 +489,22 @@ az identity federated-credential list `
 ### 6.1 Build Dataset Body JSON
 
 ```powershell
-./scripts/08-build-dataset-body.ps1 -resourceGroup $personaRg -persona $persona
+if ($persona -eq "woodgrove") {
+    # Scope Woodgrove's input dataset to a sub folder inside its container
+    ./scripts/08-build-dataset-body.ps1 -resourceGroup $personaRg -persona $persona `
+        -subdirectory "2025-09-01"
+} else {
+    # Northwind's input dataset maps to the entire container.
+    ./scripts/08-build-dataset-body.ps1 -resourceGroup $personaRg -persona $persona
+}
 ```
+
+> [!IMPORTANT]
+> The Woodgrove branch above passes `-subdirectory "2025-09-01"` so its input
+> dataset is scoped to a single date folder inside the container. Northwind's
+> input dataset is left at the container root and sees all four days produced
+> by `generate-data.ps1`. For the full parameter reference, see
+> [Optional dataset parameters](#optional-dataset-parameters) in Appendix D.
 
 > **Bring your own data**: If you want to provide your own datasets, upload your data directly to the
 > storage accounts created for your persona and update the `schema` and `accessPolicy` in the dataset
@@ -821,6 +839,12 @@ Runtime:  SKR release → KEK private → unwrap DEK → CPK header → Storage 
 
 Fields not in `allowedFields` are excluded from query access — prevents PII exposure.
 Supported formats: `csv`, `parquet`, `json`.
+
+### Optional dataset parameters
+
+| Parameter | Description |
+|---|---|
+| `subdirectory` | Prefix inside the dataset's container to scope the dataset to a sub folder(e.g. `2025-09-01`). Optional, defaults to `""` (entire container). Pass it via the `-subdirectory` parameter of `scripts/08-build-dataset-body.ps1` — see [Step 6.1](#61-build-dataset-body-json) for the call site. |
 
 ---
 

--- a/demos/analytics-using-managedcleanroom/scripts/08-build-dataset-body.ps1
+++ b/demos/analytics-using-managedcleanroom/scripts/08-build-dataset-body.ps1
@@ -28,7 +28,12 @@ param(
 
     [string]$maaUrl = "https://sharedeus.eus.attest.azure.net",
 
-    [string]$outDir = "./generated"
+    [string]$outDir = "./generated",
+
+    # Optional prefix inside the input dataset's storage container. When set,
+    # the published input dataset is scoped to that folder; when empty (default), 
+    # the dataset maps to the entire container.
+    [string]$subdirectory = ""
 )
 
 $ErrorActionPreference = 'Stop'
@@ -70,7 +75,8 @@ function New-DatasetPublishBody {
         [string]$AccessMode,
         [string[]]$AllowedFields,
         [string]$EncMode,
-        [string]$Maa
+        [string]$Maa,
+        [string]$Subdirectory = ""
     )
 
     $body = [ordered]@{
@@ -96,6 +102,10 @@ function New-DatasetPublishBody {
             tenantId  = $Identity.tenantId
             issuerUrl = $IssuerUrl
         }
+    }
+
+    if (-not [string]::IsNullOrEmpty($Subdirectory)) {
+        $body.store.subdirectory = $Subdirectory
     }
 
     if ($EncMode -eq "CPK" -and $Meta.encryption) {
@@ -132,7 +142,7 @@ $inputAllowedFields = if ($persona -eq "northwind") {
 
 $inputBody = New-DatasetPublishBody -Meta $inputMeta -Identity $identityMeta `
     -IssuerUrl $oidcIssuerUrl -AccessMode "read" -AllowedFields $inputAllowedFields `
-    -EncMode $encryptionMode -Maa $maaUrl
+    -EncMode $encryptionMode -Maa $maaUrl -Subdirectory $subdirectory
 
 $inputFile = Join-Path $publishDir "$persona-input-dataset.json"
 $inputBody | ConvertTo-Json -Depth 20 | Out-File -FilePath $inputFile -Encoding utf8


### PR DESCRIPTION
## What

Demonstrates the optional `store.subdirectory` dataset publish parameter in the **Managed Analytics REST API walkthrough** (`demos/analytics-using-managedcleanroom/`). The shared build script (`scripts/08-build-dataset-body.ps1`) now exposes `-subdirectory` as a first-class parameter; `README-API.md` §6.1 wraps the script call in a persona-conditional snippet that passes the flag for Woodgrove's input dataset and omits it for Northwind's — one dataset of one persona showcases the field, the other stays at the container root, so a single sample run demonstrates both shapes.

## Why

- `DatasetStore.subdirectory` is an existing optional field on the wire (`frontend.yaml`), supports SSE / CSE / CPK, and is already exercised by the `big-data-query-analytics` integration test in azure-cleanroom (PR #729 added the field; PR #779 lifted CPK guardrails and bumped the storage submodule).
- The README-API walks users through hand-crafted publish bodies but never showed the `subdirectory` case, so users had to read the OpenAPI spec to discover it.
- Per reviewer feedback, the sample should require the least possible reading of options: the persona-conditional lives at the README call site (visible at a glance), and the script stays generic so the same code path serves both `README.md` (CLI) and `README-API.md` (REST) walkthroughs.

## What changed

**Script** — `demos/analytics-using-managedcleanroom/scripts/08-build-dataset-body.ps1`
- New optional script parameter `-subdirectory` (default `""`).
- `New-DatasetPublishBody` takes a `-Subdirectory` parameter and sets `store.subdirectory` only when non-empty, so all `store` fields are constructed inside the function (consistent with how `accessMode`, `encryptionMode`, etc. are handled).
- The script no longer carries a persona-specific hard-coded mutation — when `-subdirectory` is omitted, the produced publish body is byte-identical to the pre-PR output, preserving backward compatibility for `README.md` (CLI walkthrough), which keeps calling the script without the new flag.

**Doc** — `demos/analytics-using-managedcleanroom/README-API.md`
- §6.1 wraps the script invocation in a persona-conditional snippet:
  ```powershell
  if ($persona -eq "woodgrove") {
      ./scripts/08-build-dataset-body.ps1 -resourceGroup $personaRg -persona $persona `
          -subdirectory "2025-09-01"
  } else {
      ./scripts/08-build-dataset-body.ps1 -resourceGroup $personaRg -persona $persona
  }
  ```
- `[!IMPORTANT]` callout explains why Woodgrove's input is scoped to a single date folder and Northwind's stays at the container root. Points at Appendix D for the parameter reference.
- New `subdirectory` row in **Appendix D – Optional dataset parameters** describing the field and pointing at §6.1 for the call site.
- Preserves the existing "Bring your own data" callout (unrelated to subdirectory).

## Backward compatibility

- `README.md` (CLI walkthrough) calls the script without `-subdirectory`. The default is `""`, the `if (-not [string]::IsNullOrEmpty(...))` guard skips the field, and the generated `store` block is unchanged.
- Output dataset publishing is untouched — `subdirectory` is threaded into the **input** dataset call only.

## Scope

- Branch: `mddanish/readme-subdirectory` → base `managed`.
- 2 files changed (single commit `073ef80`).

## Validation

End-to-end runs in single-user mode (owner = Woodgrove) on both encryption modes (executed against the earlier `82e4d34` revision, where the script applied `subdirectory="2025-09-01"` automatically for Woodgrove; the publish body is byte-identical to what the new `if/else` produces, so the E2E proof carries over):

| Mode | Collaboration | Output rows |
|---|---|---|
| SSE | `cl-spark-2ffd9d17-b950-41d0-99d6-9ecfeb29ffe1` | 25 000 |
| CPK | `cl-spark-79015102-d8f0-418d-99a5-c7b618c20927` | 25 000 (downloaded with `azcopy --cpk-by-value` and verified) |

Both runs read Woodgrove's input only from the `2025-09-01/` folder of the container; the other three date folders were present but invisible to the workload — confirming the `subdirectory` field is honored end-to-end through the frontend, CGS, and Spark workload.

Build-script verification on `073ef80` (Woodgrove metadata, CPK mode):
```
# No -subdirectory (CLI README invocation):
input.store → no subdirectory field   (byte-identical to pre-PR)

# With -subdirectory "2025-09-01" (API README Woodgrove branch):
input.store.subdirectory  = "2025-09-01"
output.store              → no subdirectory  (writes go to container root)
```
